### PR TITLE
feat(auth): implement logout with refresh token blacklist

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'rest_framework_simplejwt.token_blacklist',
     'django_filters',
     'catalog',
     'users',

--- a/config/urls.py
+++ b/config/urls.py
@@ -3,7 +3,7 @@ from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 
 from catalog.views import CategoryViewSet, ProductViewSet
-from users.views import RegisterView
+from users.views import RegisterView, LogoutView
 
 from rest_framework_simplejwt.views import (
     TokenObtainPairView,
@@ -20,4 +20,5 @@ urlpatterns = [
     path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('api/register/', RegisterView.as_view(), name='register'),
+    path('api/logout/', LogoutView.as_view(), name='logout'),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -1,7 +1,19 @@
-from rest_framework import generics
+from rest_framework import status, generics
+from rest_framework.response import Response
+from rest_framework_simplejwt.tokens import RefreshToken
 from django.contrib.auth.models import User
 from .serializers import RegisterSerializer
 
 class RegisterView(generics.CreateAPIView):
     queryset = User.objects.all()
     serializer_class = RegisterSerializer
+
+class LogoutView(generics.GenericAPIView):
+    def post(self, request, *args, **kwargs):
+        try:
+            refresh_token = request.data["refresh"]
+            token = RefreshToken(refresh_token)
+            token.blacklist()
+            return Response(status=status.HTTP_205_RESET_CONTENT)
+        except Exception:
+            return Response(status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
- Implemented logout endpoint at `/api/logout/`
- Added support for refresh token blacklist using SimpleJWT
- Configured `token_blacklist` app in settings and migrations
- Ensured refresh tokens cannot be reused once invalidated